### PR TITLE
fix minor issue with key sort in map for HACS type analysis example

### DIFF
--- a/doc/hacs.tex
+++ b/doc/hacs.tex
@@ -1595,7 +1595,7 @@ sort Exp | ↑t;
 ⟦ ⟨FLOAT#⟩ ⟧ ↑t(Float);
 // Missing case: variables -- handled by Ee below.
 
-attribute ↓e{Exp:Type};  // inherited type environment
+attribute ↓e{ID:Type};  // inherited type environment
 sort Exp | scheme Ee(Exp) ↓e ;  // propagates $e$ over Exp
 
 // These rules associate $t$ attribute with variables (missing case above).


### PR DESCRIPTION
The example listed `Exp` as the sort of the key, but then put in `token ID`, changed attribute declaration accordingly.
